### PR TITLE
⚡ Bolt: Optimize pagination by removing redundant data fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - [Astro getStaticPaths Pagination Anti-pattern]
+**Learning:** In Astro's `[...page].astro` dynamic routes, redundantly fetching and sorting collections (`getCollection`) in the component script is a significant performance bottleneck and memory waste. The `getStaticPaths` function already fetches, sorts, and paginates the data, exposing it via the `page` prop (`Astro.props.page.data`).
+**Action:** When working with Astro paginated routes, always check if `getCollection` is being called in the render scope. Refactor to use `const { page } = Astro.props` and map over `page.data` instead to avoid O(n log n) overhead on every render.

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -60,37 +60,40 @@ export default function ThemeSwitcher() {
                     width="16"
                     height="16"
                     xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
                 >
-                <path
-                    className="fill-darkText"
-                    d="M7 0h2v2H7zM12.88 1.637l1.414 1.415-1.415 1.413-1.413-1.414zM14 7h2v2h-2zM12.95 14.433l-1.414-1.413 1.413-1.415 1.415 1.414zM7 14h2v2H7zM2.98 14.364l-1.413-1.415 1.414-1.414 1.414 1.415zM0 7h2v2H0zM3.05 1.706 4.463 3.12 3.05 4.535 1.636 3.12z"
-                />
-                <path
-                    className="fill-darkText"
-                    d="M8 4C5.8 4 4 5.8 4 8s1.8 4 4 4 4-1.8 4-4-1.8-4-4-4Z"
-                />
-            </svg>
-            <svg
-                className="dark:hidden"
-                width="16"
-                height="16"
-                xmlns="http://www.w3.org/2000/svg"
+                    <path
+                        className="fill-darkText"
+                        d="M7 0h2v2H7zM12.88 1.637l1.414 1.415-1.415 1.413-1.413-1.414zM14 7h2v2h-2zM12.95 14.433l-1.414-1.413 1.413-1.415 1.415 1.414zM7 14h2v2H7zM2.98 14.364l-1.413-1.415 1.414-1.414 1.414 1.415zM0 7h2v2H0zM3.05 1.706 4.463 3.12 3.05 4.535 1.636 3.12z"
+                    />
+                    <path
+                        className="fill-darkText"
+                        d="M8 4C5.8 4 4 5.8 4 8s1.8 4 4 4 4-1.8 4-4-1.8-4-4-4Z"
+                    />
+                </svg>
+                <svg
+                    className="dark:hidden"
+                    width="16"
+                    height="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                >
+                    <path
+                        className="fill-text"
+                        d="M6.2 1C3.2 1.8 1 4.6 1 7.9 1 11.8 4.2 15 8.1 15c3.3 0 6-2.2 6.9-5.2C9.7 11.2 4.8 6.3 6.2 1Z"
+                    />
+                    <path
+                        className="fill-text"
+                        d="M12.5 5a.625.625 0 0 1-.625-.625 1.252 1.252 0 0 0-1.25-1.25.625.625 0 1 1 0-1.25 1.252 1.252 0 0 0 1.25-1.25.625.625 0 1 1 1.25 0c.001.69.56 1.249 1.25 1.25a.625.625 0 1 1 0 1.25c-.69.001-1.249.56-1.25 1.25A.625.625 0 0 1 12.5 5Z"
+                    />
+                </svg>
+            </button>
+            <span
+                id="theme-switcher-tooltip"
+                className="absolute top-8 left-1/2 -translate-x-1/2 scale-0 transition-all rounded bg-gray-800 p-2 text-xs text-white group-hover:scale-100 group-focus-within:scale-100"
             >
-                <path
-                    className="fill-text"
-                    d="M6.2 1C3.2 1.8 1 4.6 1 7.9 1 11.8 4.2 15 8.1 15c3.3 0 6-2.2 6.9-5.2C9.7 11.2 4.8 6.3 6.2 1Z"
-                />
-                <path
-                    className="fill-text"
-                    d="M12.5 5a.625.625 0 0 1-.625-.625 1.252 1.252 0 0 0-1.25-1.25.625.625 0 1 1 0-1.25 1.252 1.252 0 0 0 1.25-1.25.625.625 0 1 1 1.25 0c.001.69.56 1.249 1.25 1.25a.625.625 0 1 1 0 1.25c-.69.001-1.249.56-1.25 1.25A.625.625 0 0 1 12.5 5Z"
-                />
-            </svg>
-        </button>
-         <span
-            id="theme-switcher-tooltip"
-            className="absolute top-8 left-1/2 -translate-x-1/2 scale-0 transition-all rounded bg-gray-800 p-2 text-xs text-white group-hover:scale-100 group-focus-within:scale-100"
-            >Switch to {theme === 'dark' ? 'light' : 'dark'} mode</span
-        >
-    </div>
+                Switch to {theme === 'dark' ? 'light' : 'dark'} mode
+            </span>
+        </div>
     )
 }

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -21,18 +21,16 @@ export async function getStaticPaths({
     return paginate(blogs, { pageSize: 10 })
 }
 
-const allPosts = await getCollection('blog')
-const sortedPosts = allPosts.sort(
-    (a, b) =>
-        new Date(b.data.publishDate).valueOf() -
-        new Date(a.data.publishDate).valueOf(),
-)
+// ⚡ Bolt: Removed redundant `getCollection('blog')` and sorting here.
+// Astro's getStaticPaths already paginates the sorted data and provides it via the `page` prop.
+// Re-fetching and sorting in the component rendering phase causes unnecessary processing.
+const { page } = Astro.props
 ---
 
 <Base meta={{ title: `${config.title} - Blog` }}>
   <div class="grid grid-cols-2 gap-5 w700:grid-cols-1">
     {
-      sortedPosts.map((post) => (
+      page.data.map((post) => (
         <Card
           url={post.slug}
           heroImage={post.data.heroImage}

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -21,18 +21,16 @@ export async function getStaticPaths({
     return paginate(blogs, { pageSize: 10 })
 }
 
-const allProjects = await getCollection('project')
-const sortedProjects = allProjects.sort(
-    (a, b) =>
-        new Date(b.data.publishDate).valueOf() -
-        new Date(a.data.publishDate).valueOf(),
-)
+// ⚡ Bolt: Removed redundant `getCollection('project')` and sorting here.
+// Astro's getStaticPaths already paginates the sorted data and provides it via the `page` prop.
+// Re-fetching and sorting in the component rendering phase causes unnecessary processing.
+const { page } = Astro.props
 ---
 
 <Base meta={{ title: `${config.title} - Project` }}>
   <div class="grid grid-cols-2 gap-5 w700:grid-cols-1">
     {
-      sortedProjects.map((project) => (
+      page.data.map((project) => (
         <Card
           url={project.slug}
           heroImage={project.data.heroImage}


### PR DESCRIPTION
**💡 What:** Replaced redundant `getCollection` and `sort()` operations in `[...page].astro` files for the blog and project sections. It now uses the `page.data` passed via `Astro.props` from `getStaticPaths`.

**🎯 Why:** Astro's `getStaticPaths` function for pagination already fetches, sorts, and paginates the data collections. The template was redundantly re-fetching the entire collection, sorting it again, and mapping over the whole array on every page render. This bypassed the pagination feature and added significant overhead. Using `page.data` correctly renders the paginated data.

**📊 Impact:** Eliminates $O(n \log n)$ processing and $O(n)$ rendering latency per page generated, drastically improving performance during site build/page generation.

**🔬 Measurement:** Verified that running `npm run build` succeeds smoothly and correctly generates paginated index pages. Also ran `npm run lint` successfully after resolving some basic SVG accessibility linting issues.

---
*PR created automatically by Jules for task [7848775924840597762](https://jules.google.com/task/7848775924840597762) started by @indra87g*