### PR TITLE
🎨 Palette: Enhance accessibility of navigation toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Dynamic ARIA Labels and SVG Titles
+**Learning:** For toggle buttons that control state (like a mobile menu), a static `aria-label` like "Toggle menu" is less informative than a dynamic one ("Open menu" / "Close menu"). Additionally, inner SVG `<title>` tags can cause screen readers to announce conflicting or redundant labels when the parent button already has an `aria-label`. SVGs in descriptive buttons should be explicitly hidden with `aria-hidden="true"`.
+**Action:** Use state-aware `aria-label`s on interactive toggles, and use `aria-hidden="true"` to explicitly hide decorative SVGs instead of relying on `<title>` tags when the parent element provides accessibility.

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -8,8 +8,8 @@ const MenuIcon = () => (
         viewBox="0 0 24 24"
         stroke="currentColor"
         strokeWidth={2}
+        aria-hidden="true"
     >
-        <title>Open menu</title>
         <path
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -26,8 +26,8 @@ const CloseIcon = () => (
         viewBox="0 0 24 24"
         stroke="currentColor"
         strokeWidth={2}
+        aria-hidden="true"
     >
-        <title>Close menu</title>
         <path
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -66,8 +66,8 @@ export default function MobileNav() {
             <button
                 type="button"
                 onClick={() => setIsOpen(!isOpen)}
-                className="z-50 text-text dark:text-main"
-                aria-label="Toggle menu"
+                className="z-50 text-text dark:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main"
+                aria-label={isOpen ? 'Close menu' : 'Open menu'}
                 aria-expanded={isOpen}
             >
                 {isOpen ? <CloseIcon /> : <MenuIcon />}

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -53,7 +53,7 @@ export default function ThemeSwitcher() {
                         : 'Switch to dark mode'
                 }
                 aria-describedby="theme-switcher-tooltip"
-                className="flex items-center justify-center"
+                className="flex items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main"
             >
                 <svg
                     className="hidden dark:block"


### PR DESCRIPTION
💡 **What**: Added visible focus rings (`focus-visible:ring-2`) to the Mobile Nav and Theme Switcher buttons. Replaced static "Toggle menu" `aria-label` with dynamic "Open menu" / "Close menu" states. Removed redundant `<title>` tags from inner SVGs and added `aria-hidden="true"`.

🎯 **Why**: Ensures keyboard users can clearly see when navigation toggle buttons are focused. Prevents screen readers from double-announcing redundant labels and provides better contextual feedback (open vs closed state) for the mobile menu.

📸 **Before/After**: Keyboard navigation tab focuses on nav buttons with a solid ring. Screen readers will no longer announce redundant SVG `<title>` tags when reading the parent button's label.

♿ **Accessibility**: Improved WCAG compliance by ensuring explicit focus visibility and cleaning up confusing screen reader semantics.

---
*PR created automatically by Jules for task [4173857815532546356](https://jules.google.com/task/4173857815532546356) started by @indra87g*