### PR TITLE
⚡ Bolt: Parallelize data fetching and lazy load images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2023-10-27 - [Astro getStaticPaths Pagination Anti-pattern]
 **Learning:** In Astro's `[...page].astro` dynamic routes, redundantly fetching and sorting collections (`getCollection`) in the component script is a significant performance bottleneck and memory waste. The `getStaticPaths` function already fetches, sorts, and paginates the data, exposing it via the `page` prop (`Astro.props.page.data`).
 **Action:** When working with Astro paginated routes, always check if `getCollection` is being called in the render scope. Refactor to use `const { page } = Astro.props` and map over `page.data` instead to avoid O(n log n) overhead on every render.
+
+## 2023-10-27 - [Parallelize Multiple Astro Content Collection Fetches]
+**Learning:** Sequential `getCollection` calls in Astro pages (e.g., `const blogs = await getCollection('blog'); const projects = await getCollection('project');`) cause unnecessary I/O and parsing bottlenecks during the build process or SSR, as each collection fetch blocks the next.
+**Action:** Always use `Promise.all` when a page requires fetching multiple distinct collections simultaneously (e.g., `const [blogs, projects] = await Promise.all([getCollection('blog'), getCollection('project')]);`) to optimize data fetching performance.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,12 +10,18 @@ import { getCollection } from 'astro:content'
 import PostCard from '@/components/PostCard.astro'
 import ProjectCard from '@/components/ProjectCard.astro'
 
-const posts = (await getCollection('blog'))
+// ⚡ Bolt: Fetch collections in parallel to reduce processing time
+const [blogEntries, projectEntries] = await Promise.all([
+    getCollection('blog'),
+    getCollection('project'),
+])
+
+const posts = blogEntries
     .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf())
     .slice(0, 3)
 
-const projects = (await getCollection('project'))
+const projects = projectEntries
     .filter((project) => !project.data.draft)
     .sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf())
     .slice(0, 3)
@@ -98,12 +104,12 @@ const projects = (await getCollection('project'))
   <div class="mt-16 flex flex-col items-center justify-center gap-4">
     <h2 class="text-3xl font-bold text-center">GitHub Stats</h2>
     <p align="center">
-      <img src="https://github-readme-stats.vercel.app/api?username=indra87g&show_icons=true&theme=radical" alt="Indra's GitHub Stats" />
-      <img src="https://github-readme-streak-stats.herokuapp.com/?user=indra87g&theme=radical" alt="GitHub Streak Stats" />
+      <img loading="lazy" decoding="async" src="https://github-readme-stats.vercel.app/api?username=indra87g&show_icons=true&theme=radical" alt="Indra's GitHub Stats" />
+      <img loading="lazy" decoding="async" src="https://github-readme-streak-stats.herokuapp.com/?user=indra87g&theme=radical" alt="GitHub Streak Stats" />
     </p>
 
     <p align="center">
-      <img src="https://github-profile-trophy.vercel.app/?username=indra87g&theme=radical&margin-w=10&rank=A,AA,AAA,S,SS,SSS,?&row=2&column=3" alt="Trophies" />
+      <img loading="lazy" decoding="async" src="https://github-profile-trophy.vercel.app/?username=indra87g&theme=radical&margin-w=10&rank=A,AA,AAA,S,SS,SSS,?&row=2&column=3" alt="Trophies" />
     </p>
   </div>
 </Base>


### PR DESCRIPTION
💡 **What:** 
- Parallelized the fetching of `blog` and `project` content collections in `src/pages/index.astro` using `Promise.all`.
- Added `loading="lazy"` and `decoding="async"` to the three external GitHub stats images at the bottom of the page.
- Added an entry to `.jules/bolt.md` regarding parallel collection fetching.

🎯 **Why:** 
- `getCollection` performs file system I/O and markdown parsing. Running these sequentially blocks the thread and increases processing time. Parallelizing them reduces this bottleneck during build/SSR.
- The external GitHub images are below the fold and fetched from third-party APIs. Not lazy-loading them blocks the initial page render unnecessarily.

📊 **Impact:** 
- Faster build times and improved Time to First Byte (TTFB) during SSR due to parallel I/O.
- Improved Largest Contentful Paint (LCP) and initial page load speed by deferring off-screen external images.

🔬 **Measurement:** 
- Compare build times (`pnpm build`) or SSR rendering speed. Network tab will show the images are no longer requested immediately upon page load but only as the user scrolls down.

---
*PR created automatically by Jules for task [9052370167254761767](https://jules.google.com/task/9052370167254761767) started by @indra87g*