### PR TITLE
🛡️ Sentinel: [MEDIUM] Add basic security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Found `<a>` tags with `target="_blank"` without `rel="noopener noreferrer"` in `src/pages/cv.astro`.
 **Learning:** External links opened in a new tab without `noopener noreferrer` can access the original window object via `window.opener`. This exposes the site to Reverse Tabnabbing, where the newly opened page can maliciously redirect or manipulate the original page, potentially leading to phishing or other attacks.
 **Prevention:** Always add `rel="noopener noreferrer"` whenever using `target="_blank"` for external links to protect the original page and preserve user security.
+## 2024-05-24 - [Cloudflare Pages Security Headers]
+**Vulnerability:** Missing default security headers (e.g., `X-Frame-Options`, `X-Content-Type-Options`) for a Cloudflare Pages deployed Astro site.
+**Learning:** Security headers must be explicitly set for Astro projects deployed to Cloudflare Pages using a `public/_headers` file, as the framework/adapter doesn't inject them by default.
+**Prevention:** Always include a `_headers` file with basic defense-in-depth headers in projects targeting Cloudflare Pages.

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,4 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was missing basic security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), leaving it susceptible to clickjacking, MIME-type sniffing, and potentially leaking referrer information.
🎯 **Impact:** An attacker could potentially embed the site in a malicious iframe to perform clickjacking attacks or exploit MIME-type sniffing vulnerabilities.
🔧 **Fix:** Added a `public/_headers` file containing standard defense-in-depth security headers, which Cloudflare Pages will automatically apply to all responses.
✅ **Verification:** Verified by checking the contents of the `public/_headers` file and ensuring the project still builds correctly (`pnpm build`). The headers will be applied once deployed.

---
*PR created automatically by Jules for task [797418081034376652](https://jules.google.com/task/797418081034376652) started by @indra87g*