### PR TITLE
🎨 Palette: Add active state and keyboard focus to navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-20 - [Add Skip-to-Content Link]
 **Learning:** Found nested `<main>` tags within `src/layouts/Base.astro`. Replaced inner `<main>` tag with `<div>` which is critical for making `tabindex="-1"` and `focus:outline-none` on target element work cleanly.
 **Action:** Always check the element being used as the `#main-content` target to ensure it is structurally valid HTML so that focus handling and screen reader announcements behave properly.
+## 2025-02-23 - [Active Navigation Link Indicators & Focus State]
+**Learning:** Hardcoded navigation links without a dynamic way to show the current active page or clear keyboard focus states cause a significant drop in spatial orientation for users. Using `Astro.url.pathname` and `aria-current="page"` alongside focus visible classes drastically improves accessibility and navigational confidence.
+**Action:** Always ensure that `aria-current="page"` is dynamically assigned on standard navigation links and that keyboard-navigable elements have a visible `focus-visible` outline or ring style.

--- a/package.json
+++ b/package.json
@@ -58,10 +58,5 @@
         "prettier-plugin-astro": "^0.14.0",
         "prettier-plugin-tailwindcss": "^0.6.5"
     },
-    "trustedDependencies": [
-        "@biomejs/biome",
-        "esbuild",
-        "sharp",
-        "workerd"
-    ]
+    "trustedDependencies": ["@biomejs/biome", "esbuild", "sharp", "workerd"]
 }

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -36,7 +36,9 @@ const CloseIcon = () => (
     </svg>
 )
 
-export default function MobileNav() {
+export default function MobileNav({
+    currentPath = '',
+}: { currentPath?: string }) {
     const [isOpen, setIsOpen] = useState(false)
 
     useEffect(() => {
@@ -79,13 +81,33 @@ export default function MobileNav() {
                 }`}
             >
                 <div className="flex flex-col items-start gap-4 p-4">
-                    <a href="/blog" className="hover:underline">
+                    <a
+                        href="/blog"
+                        className={`hover:underline rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${currentPath.startsWith('/blog') ? 'text-main font-bold' : ''}`}
+                        aria-current={
+                            currentPath.startsWith('/blog') ? 'page' : undefined
+                        }
+                    >
                         Blog
                     </a>
-                    <a href="/project" className="hover:underline">
+                    <a
+                        href="/project"
+                        className={`hover:underline rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${currentPath.startsWith('/project') ? 'text-main font-bold' : ''}`}
+                        aria-current={
+                            currentPath.startsWith('/project')
+                                ? 'page'
+                                : undefined
+                        }
+                    >
                         Project
                     </a>
-                    <a href="/cv" className="hover:underline">
+                    <a
+                        href="/cv"
+                        className={`hover:underline rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${currentPath.startsWith('/cv') ? 'text-main font-bold' : ''}`}
+                        aria-current={
+                            currentPath.startsWith('/cv') ? 'page' : undefined
+                        }
+                    >
                         CV
                     </a>
                 </div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,28 +1,30 @@
 ---
 import ThemeSwitcher from '@/components/ThemeSwitcher'
 import MobileNav from '@/components/MobileNav.tsx'
+
+const pathname = Astro.url.pathname
 ---
 
 <nav class="fixed left-0 top-0 z-50 w-full px-5">
   <div
     class="z-50 mt-5 flex h-[70px] w-full items-center justify-between rounded-base border-2 border-border bg-white px-5 text-text dark:border-darkBorder dark:bg-secondaryBlack dark:text-darkText"
   >
-    <a href="/">
+    <a href="/" class="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main">
       <h2 class="text-3xl font-heading w500:text-2xl w400:text-xl text-main">INDRA87G</h2>
     </a>
 
     <!-- Desktop Menu -->
     <div class="hidden items-center text-lg md:flex">
-      <a class="mr-10 hover:text-main" href="/blog">Blog</a>
-      <a class="mr-10 hover:text-main" href="/project">Project</a>
-      <a class="mr-10 hover:text-main" href="/cv">CV</a>
+      <a class={`mr-10 hover:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${pathname.startsWith('/blog') ? 'text-main font-bold' : ''}`} href="/blog" aria-current={pathname.startsWith('/blog') ? 'page' : undefined}>Blog</a>
+      <a class={`mr-10 hover:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${pathname.startsWith('/project') ? 'text-main font-bold' : ''}`} href="/project" aria-current={pathname.startsWith('/project') ? 'page' : undefined}>Project</a>
+      <a class={`mr-10 hover:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${pathname.startsWith('/cv') ? 'text-main font-bold' : ''}`} href="/cv" aria-current={pathname.startsWith('/cv') ? 'page' : undefined}>CV</a>
       <ThemeSwitcher client:load />
     </div>
 
     <!-- Mobile Menu -->
     <div class="flex items-center gap-4 md:hidden">
       <ThemeSwitcher client:load />
-      <MobileNav client:load />
+      <MobileNav currentPath={pathname} client:load />
     </div>
   </div>
 </nav>


### PR DESCRIPTION
💡 **What:** Added active page indication to desktop and mobile navigation links along with clear focus visible styles for keyboard navigation.
🎯 **Why:** To improve spatial orientation for users so they know which page they are currently on and to ensure keyboard users have a visible focus indicator when navigating the menu.
📸 **Before/After:** The active page link in the navigation menu is now bolded and colored with the main accent color, and tabbing through the navigation provides clear focus rings.
♿ **Accessibility:** Added the `aria-current="page"` attribute dynamically based on the current URL path to inform screen readers of the active page. Improved visual keyboard navigation with `focus-visible`.

---
*PR created automatically by Jules for task [9280718767351475625](https://jules.google.com/task/9280718767351475625) started by @indra87g*