### PR TITLE
🎨 Palette: [Accessibility] Add ARIA labels and focus states to social links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-02-23 - [Active Navigation Link Indicators & Focus State]
 **Learning:** Hardcoded navigation links without a dynamic way to show the current active page or clear keyboard focus states cause a significant drop in spatial orientation for users. Using `Astro.url.pathname` and `aria-current="page"` alongside focus visible classes drastically improves accessibility and navigational confidence.
 **Action:** Always ensure that `aria-current="page"` is dynamically assigned on standard navigation links and that keyboard-navigable elements have a visible `focus-visible` outline or ring style.
+## 2024-05-25 - [Accessibility & Feedback for Icon-Only Links]
+**Learning:** Icon-only links (like social links) often rely solely on the `title` attribute, which is insufficient for screen readers and does not provide an interactive visual state. Providing explicit `aria-label` attributes and ensuring visible focus states (`focus-visible:ring-2 focus-visible:ring-main`) and hover animations greatly enhance accessibility and the interactive feel of the component.
+**Action:** Always verify that icon-only interactive elements (links or buttons) include an `aria-label` and have robust focus and hover feedback classes applied.

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -19,7 +19,8 @@ const {
       target="_blank"
       rel="me noreferrer noopener"
       title="Email"
-      class="xs:text-lg flex items-center gap-2 text-base"
+      aria-label="Email"
+      class="xs:text-lg flex items-center gap-2 text-base rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main hover:scale-110 transition-transform"
     >
       <Icon
         name="tabler:mail"
@@ -33,7 +34,8 @@ const {
       target="_blank"
       rel="me noreferrer noopener"
       title="Facebook"
-      class="xs:text-lg flex items-center gap-2 text-base"
+      aria-label="Facebook"
+      class="xs:text-lg flex items-center gap-2 text-base rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main hover:scale-110 transition-transform"
     >
       <Icon
         name="tabler:brand-facebook"
@@ -47,7 +49,8 @@ const {
       target="_blank"
       rel="me noreferrer noopener"
       title="Linkedin"
-      class="xs:text-lg flex items-center gap-2 text-base"
+      aria-label="Linkedin"
+      class="xs:text-lg flex items-center gap-2 text-base rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main hover:scale-110 transition-transform"
     >
       <Icon
         name="tabler:brand-linkedin"
@@ -61,7 +64,8 @@ const {
       target="_blank"
       rel="me noreferrer noopener"
       title="Github"
-      class="xs:text-lg flex items-center gap-2 text-base"
+      aria-label="Github"
+      class="xs:text-lg flex items-center gap-2 text-base rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main hover:scale-110 transition-transform"
     >
       <Icon
         name="tabler:brand-github"
@@ -75,7 +79,8 @@ const {
       target="_blank"
       rel="me noreferrer noopener"
       title="Trakteer"
-      class="xs:text-lg flex items-center gap-2 text-base"
+      aria-label="Trakteer"
+      class="xs:text-lg flex items-center gap-2 text-base rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main hover:scale-110 transition-transform"
     >
       <Icon
         name="tabler:brand-bluesky"


### PR DESCRIPTION
**💡 What:**
Added explicit `aria-label`s, keyboard `focus-visible` styles, and interactive `hover:scale-110` transformations to the icon-only social links in the `SocialLinks.astro` component.

**🎯 Why:**
Icon-only links that rely solely on `title` attributes are less reliable for screen readers. Furthermore, these links completely lacked keyboard focus indicators, making them impossible to navigate confidently without a mouse. The added hover scale effect brings a subtle touch of delight and immediate feedback.

**📸 Before/After:**
*(See Playwright screenshot demonstrating the new clear yellow focus ring on the Email icon)*

**♿ Accessibility:**
* Added specific `aria-label`s to all 5 social links (Email, Facebook, LinkedIn, GitHub, Trakteer).
* Added `focus-visible:ring-2 focus-visible:ring-main focus-visible:outline-none` to guarantee high-visibility keyboard focus states that match the design system.

---
*PR created automatically by Jules for task [17811034526811744174](https://jules.google.com/task/17811034526811744174) started by @indra87g*