### PR TITLE
🎨 Palette: Add tactile keyboard focus states to content cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - [Accessibility & Feedback for Icon-Only Links]
 **Learning:** Icon-only links (like social links) often rely solely on the `title` attribute, which is insufficient for screen readers and does not provide an interactive visual state. Providing explicit `aria-label` attributes and ensuring visible focus states (`focus-visible:ring-2 focus-visible:ring-main`) and hover animations greatly enhance accessibility and the interactive feel of the component.
 **Action:** Always verify that icon-only interactive elements (links or buttons) include an `aria-label` and have robust focus and hover feedback classes applied.
+## 2024-05-23 - [Tactile Keyboard Focus States]
+**Learning:** Playful design elements (like brutalist push-down hover effects on cards) often exclude keyboard users who rely on standard outlines. Expanding these exact translation/shadow visual changes to `focus-visible` ensures an equitable, delightful experience for keyboard navigation while still providing a clear focus outline.
+**Action:** Always replicate interactive hover translations or shadow changes to `focus-visible` classes so that keyboard users experience the same tactile feedback as mouse users.

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -6,7 +6,7 @@ const { url, heroImage, heroAlt, title, description, draft, publishDate } =
 
 <a
   href={`/blog/${url}`}
-  class="rounded-base border-2 border-border bg-main p-4 text-text shadow-light transition-all last:mb-0 hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none dark:border-darkBorder dark:shadow-dark dark:hover:shadow-none"
+  class="rounded-base border-2 border-border bg-main p-4 text-text shadow-light transition-all last:mb-0 hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none focus-visible:translate-x-boxShadowX focus-visible:translate-y-boxShadowY focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black dark:border-darkBorder dark:shadow-dark dark:hover:shadow-none dark:focus-visible:shadow-none dark:focus-visible:ring-white"
 >
   <Image
     width={1280}
@@ -26,6 +26,7 @@ const { url, heroImage, heroAlt, title, description, draft, publishDate } =
       xmlns="http://www.w3.org/2000/svg"
       class="mr-3 h-4 w-4 w500:h-3 w500:w-3"
       viewBox="-0.5 0 15 15"
+      aria-hidden="true"
     >
       <path
         class="fill-lightModeText dark:fill-darkModeText"

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -6,7 +6,7 @@ const { url, heroImage, heroAlt, title, description, draft, publishDate } =
 
 <a
   href={`/project/${url}`}
-  class="rounded-base border-2 border-border bg-main p-4 text-text shadow-light transition-all last:mb-0 hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none dark:border-darkBorder dark:shadow-dark dark:hover:shadow-none"
+  class="rounded-base border-2 border-border bg-main p-4 text-text shadow-light transition-all last:mb-0 hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none focus-visible:translate-x-boxShadowX focus-visible:translate-y-boxShadowY focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black dark:border-darkBorder dark:shadow-dark dark:hover:shadow-none dark:focus-visible:shadow-none dark:focus-visible:ring-white"
 >
   <Image
     width={1280}
@@ -26,6 +26,7 @@ const { url, heroImage, heroAlt, title, description, draft, publishDate } =
       xmlns="http://www.w3.org/2000/svg"
       class="mr-3 h-4 w-4 w500:h-3 w500:w-3"
       viewBox="-0.5 0 15 15"
+      aria-hidden="true"
     >
       <path
         class="fill-lightModeText dark:fill-darkModeText"


### PR DESCRIPTION
💡 **What:** Added tactile keyboard focus states to PostCard and ProjectCard, matching the visual neo-brutalist push-down effect normally only seen on hover. Also added `aria-hidden="true"` to the decorative calendar SVGs inside the cards.

🎯 **Why:** Keyboard users who navigate via the Tab key previously only received the browser's default outline with no tactile feedback. Mirroring the hover translations to `focus-visible` ensures an equitable and delightful experience across input methods. Hiding the calendar SVG prevents redundant and potentially confusing screen reader announcements, since the adjacent text already conveys the date.

📸 **Before/After:** No visual changes for mouse users. Keyboard users will now see the card press down alongside a high-contrast black/white outline when the card receives focus.

♿ **Accessibility:** 
- Improved keyboard accessibility with robust `focus-visible` styles (`focus-visible:ring-2`, tactile translation).
- Reduced screen reader noise by hiding decorative icons (`aria-hidden="true"`).

---
*PR created automatically by Jules for task [993913958098378039](https://jules.google.com/task/993913958098378039) started by @indra87g*