### PR TITLE
🎨 Palette: Add visual and accessible indicators for external links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-02-28 - Theme token consistency in visual feedback
 **Learning:** Found that the CV page's `TimeLine.astro` component was using an undefined Tailwind color class (`bg-primary`), causing the timeline visual indicators (dots and lines) to be completely invisible. In a design system that relies on specific theme-aware tokens (like `bg-main`, `border-border`), using generic classes from other templates can break visual feedback and UX.
 **Action:** Replace undefined classes with the correct theme tokens to restore the intended visual hierarchy and ensure components adapt correctly to light/dark modes.
+
+## 2025-02-28 - Missing visual and screen reader indicators for external links
+**Learning:** Found that external links (`target="_blank"`) across multiple components (CV certificates, Footer commit dialog) lack both visual indicators for sighted users and auditory indicators for screen reader users. This means users are not informed before clicking that they will be taken out of the current context.
+**Action:** Consistently apply an inline `tabler:external-link` icon (hidden from screen readers via `aria-hidden="true"`) alongside an `.sr-only` span text like "(opens in a new tab)" to all external links. Additionally, wrap these links in `inline-flex items-center gap-1` to ensure correct alignment between the text and icon.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 import { execSync } from 'node:child_process'
+import { Icon } from 'astro-icon/components'
 
 const today = new Date()
 let commitMessage = 'No commit info'
@@ -38,26 +39,26 @@ try {
     <div>
       <h3 class="font-semibold text-main">General</h3>
       <ul class="mt-2 space-y-2">
-        <li><a href="/blog" class="hover:underline">Blog</a></li>
-        <li><a href="/explore" class="hover:underline">Explore</a></li>
-        <li><a href="/projects" class="hover:underline">Projects</a></li>
+        <li><a href="/blog" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Blog</a></li>
+        <li><a href="/explore" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Explore</a></li>
+        <li><a href="/projects" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Projects</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-semibold text-main">Navigations</h3>
       <ul class="mt-2 space-y-2">
-        <li><a href="#" class="hover:underline">Talks</a></li>
-        <li><a href="#" class="hover:underline">Credits</a></li>
-        <li><a href="#" class="hover:underline">Support</a></li>
-        <li><a href="#" class="hover:underline">Resume</a></li>
+        <li><a href="#" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Talks</a></li>
+        <li><a href="#" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Credits</a></li>
+        <li><a href="#" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Support</a></li>
+        <li><a href="#" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Resume</a></li>
       </ul>
     </div>
     <div>
       <h3 class="font-semibold text-main">Ext. Resources</h3>
       <ul class="mt-2 space-y-2">
-        <li><a href="#" class="hover:underline">Bookmarks</a></li>
-        <li><a href="#" class="hover:underline">Analytics</a></li>
-        <li><a href="#" class="hover:underline">RSS</a></li>
+        <li><a href="#" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Bookmarks</a></li>
+        <li><a href="#" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">Analytics</a></li>
+        <li><a href="#" class="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm">RSS</a></li>
         <li>
           <button
             id="showCommitDialogBtn"
@@ -90,10 +91,10 @@ try {
       class="whitespace-pre-wrap rounded-base bg-stone-100 p-4 font-mono text-sm dark:bg-stone-800"
       ><a
         href=`https://github.com/indra87g/indra87g.vercel.app/commit/${commitSha}`
-        class="hover:underline text-main"
+        class="hover:underline text-main focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm inline"
         target="_blank"
         rel="noopener noreferrer"
-      >{commitMessage}</a></pre
+      >{commitMessage} <Icon name="tabler:external-link" class="h-4 w-4 inline mb-1" aria-hidden="true" /><span class="sr-only">(opens in a new tab)</span></a></pre
     >
   </div>
 </dialog>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -2,6 +2,7 @@
 import config from '@/config'
 import Base from '@/layouts/Base.astro'
 import TimeLine from '@/components/cv/TimeLine.astro'
+import { Icon } from 'astro-icon/components'
 ---
 
 <Base meta={{ title: `${config.title} - CV` }}>
@@ -76,43 +77,51 @@ import TimeLine from '@/components/cv/TimeLine.astro'
   <ul class="mx-6 mb-10 grid list-disc gap-2">
     <li>
       <a
-        class="hover:text-emerald-600"
+        class="hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm inline-flex items-center gap-1"
         href="https://raw.githubusercontent.com/indra87g/indra87g/main/certificates/dqlab_1.pdf"
         target="_blank"
         rel="noopener noreferrer"
       >
-        FREECLASS: Data Science Fundamentals - DQLab</a
-      >
+        FREECLASS: Data Science Fundamentals - DQLab
+        <Icon name="tabler:external-link" class="h-4 w-4" aria-hidden="true" />
+        <span class="sr-only">(opens in a new tab)</span>
+      </a>
     </li>
     <li>
       <a
-        class="hover:text-emerald-600"
+        class="hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm inline-flex items-center gap-1"
         href="https://raw.githubusercontent.com/indra87g/indra87g/main/certificates/santrikoding_1.png"
         target="_blank"
         rel="noopener noreferrer"
       >
-        FullStack Javascript Developer dengan Express dan Vue - SantriKoding</a
-      >
+        FullStack Javascript Developer dengan Express dan Vue - SantriKoding
+        <Icon name="tabler:external-link" class="h-4 w-4" aria-hidden="true" />
+        <span class="sr-only">(opens in a new tab)</span>
+      </a>
     </li>
     <li>
       <a
-        class="hover:text-emerald-600"
+        class="hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm inline-flex items-center gap-1"
         href="https://raw.githubusercontent.com/indra87g/indra87g/main/certificates/idcamp2024_1.pdf"
         target="_blank"
         rel="noopener noreferrer"
       >
-        Belajar Visualisasi Data - IDCamp IOH 2024</a
-      >
+        Belajar Visualisasi Data - IDCamp IOH 2024
+        <Icon name="tabler:external-link" class="h-4 w-4" aria-hidden="true" />
+        <span class="sr-only">(opens in a new tab)</span>
+      </a>
     </li>
     <li>
       <a
-        class="hover:text-emerald-600"
+        class="hover:text-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main rounded-sm inline-flex items-center gap-1"
         href="https://raw.githubusercontent.com/indra87g/indra87g/main/certificates/idcamp2024_2.pdf"
         target="_blank"
         rel="noopener noreferrer"
       >
-        Memulai Pemrograman dengan Python - IDCamp IOH 2024</a
-      >
+        Memulai Pemrograman dengan Python - IDCamp IOH 2024
+        <Icon name="tabler:external-link" class="h-4 w-4" aria-hidden="true" />
+        <span class="sr-only">(opens in a new tab)</span>
+      </a>
     </li>
   </ul>
 


### PR DESCRIPTION
This patch enhances the UX and accessibility of external links (`target="_blank"`) across the CV page and the Footer commit dialog.

- Appended `tabler:external-link` icons to all external links to visually inform sighted users that a new tab will open.
- Added screen reader text (`<span class="sr-only">(opens in a new tab)</span>`) to properly announce the link behavior to assistive technologies.
- Ensured consistent `focus-visible:ring-2 focus-visible:ring-main` styling on the footer navigation links for keyboard users.
- Updated the Palette journal to record learnings on external link indicators.

---
*PR created automatically by Jules for task [6105514748613280035](https://jules.google.com/task/6105514748613280035) started by @indra87g*