### PR TITLE
🎨 Palette: Enhance mobile menu with Escape/click-outside to close and ARIA controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-28 - Missing visual and screen reader indicators for external links
 **Learning:** Found that external links (`target="_blank"`) across multiple components (CV certificates, Footer commit dialog) lack both visual indicators for sighted users and auditory indicators for screen reader users. This means users are not informed before clicking that they will be taken out of the current context.
 **Action:** Consistently apply an inline `tabler:external-link` icon (hidden from screen readers via `aria-hidden="true"`) alongside an `.sr-only` span text like "(opens in a new tab)" to all external links. Additionally, wrap these links in `inline-flex items-center gap-1` to ensure correct alignment between the text and icon.
+
+## 2024-05-18 - Mobile Menu Accessibility and UX
+**Learning:** Custom dropdown/menu components (like the React mobile nav) are confusing for keyboard and screen-reader users without explicit closure methods (Escape key) and an easy way to back out (click outside). Missing `aria-controls` disconnects the toggle from the actual menu content.
+**Action:** Always implement "Escape to close" and "Click outside to close" paired with `aria-controls` for any custom dropdown component to provide an accessible and expected UX.

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 const MenuIcon = () => (
     <svg
@@ -40,6 +40,34 @@ export default function MobileNav({
     currentPath = '',
 }: { currentPath?: string }) {
     const [isOpen, setIsOpen] = useState(false)
+    const navRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (
+                navRef.current &&
+                !navRef.current.contains(event.target as Node)
+            ) {
+                setIsOpen(false)
+            }
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setIsOpen(false)
+            }
+        }
+
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside)
+            document.addEventListener('keydown', handleKeyDown)
+        }
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside)
+            document.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [isOpen])
 
     useEffect(() => {
         const handleResize = () => {
@@ -64,18 +92,20 @@ export default function MobileNav({
     }, [isOpen])
 
     return (
-        <div className="md:hidden">
+        <div className="md:hidden" ref={navRef}>
             <button
                 type="button"
                 onClick={() => setIsOpen(!isOpen)}
                 className="z-50 text-text dark:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main"
                 aria-label={isOpen ? 'Close menu' : 'Open menu'}
                 aria-expanded={isOpen}
+                aria-controls="mobile-menu"
             >
                 {isOpen ? <CloseIcon /> : <MenuIcon />}
             </button>
 
             <div
+                id="mobile-menu"
                 className={`absolute right-4 top-[90px] z-40 w-48 rounded-base border-2 border-border bg-bg text-text transition-all duration-300 ease-in-out dark:border-main dark:bg-darkBg dark:text-main ${
                     isOpen ? 'opacity-100 visible' : 'opacity-0 invisible'
                 }`}


### PR DESCRIPTION
💡 **What**: Added "Escape to close" and "Click outside to close" behaviors to the `MobileNav` React component, and connected the toggle button to the menu container using the `aria-controls` attribute.
🎯 **Why**: Custom dropdown components (like the mobile menu) are confusing and frustrating for keyboard and screen-reader users without explicit closure methods and an easy way to back out (by clicking outside). The missing `aria-controls` disconnected the toggle from the actual menu content.
♿ **Accessibility**: Improved keyboard navigation support (Escape to close) and screen reader support (ARIA controls mapping).

---
*PR created automatically by Jules for task [13171110365993013314](https://jules.google.com/task/13171110365993013314) started by @indra87g*