### PR TITLE
🎨 Palette: Add Escape and click-outside to close MobileNav

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-02-28 - Missing visual and screen reader indicators for external links
 **Learning:** Found that external links (`target="_blank"`) across multiple components (CV certificates, Footer commit dialog) lack both visual indicators for sighted users and auditory indicators for screen reader users. This means users are not informed before clicking that they will be taken out of the current context.
 **Action:** Consistently apply an inline `tabler:external-link` icon (hidden from screen readers via `aria-hidden="true"`) alongside an `.sr-only` span text like "(opens in a new tab)" to all external links. Additionally, wrap these links in `inline-flex items-center gap-1` to ensure correct alignment between the text and icon.
+
+## 2025-02-28 - Custom dropdown and mobile menu accessibility
+**Learning:** Found that custom dropdown and mobile menu components built with React (e.g., `MobileNav.tsx`) were missing critical accessibility expected interactions: closing on `Escape` keypress, closing on clicking outside the component, and linking the toggle button to the expanding menu with `aria-controls`. Without these, keyboard and screen reader users can get trapped or disoriented.
+**Action:** When implementing or reviewing custom toggles or dropdown menus, ensure `useEffect` hooks bind `keydown` (for Escape) and `mousedown` (for click-outside) event listeners, and use `aria-controls` on the toggle mapped to the `id` of the menu content.

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 const MenuIcon = () => (
     <svg
@@ -40,6 +40,7 @@ export default function MobileNav({
     currentPath = '',
 }: { currentPath?: string }) {
     const [isOpen, setIsOpen] = useState(false)
+    const navRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
         const handleResize = () => {
@@ -63,19 +64,48 @@ export default function MobileNav({
         }
     }, [isOpen])
 
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (
+                navRef.current &&
+                !navRef.current.contains(event.target as Node)
+            ) {
+                setIsOpen(false)
+            }
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setIsOpen(false)
+            }
+        }
+
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside)
+            document.addEventListener('keydown', handleKeyDown)
+        }
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside)
+            document.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [isOpen])
+
     return (
-        <div className="md:hidden">
+        <div className="md:hidden" ref={navRef}>
             <button
                 type="button"
                 onClick={() => setIsOpen(!isOpen)}
                 className="z-50 text-text dark:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main"
                 aria-label={isOpen ? 'Close menu' : 'Open menu'}
                 aria-expanded={isOpen}
+                aria-controls="mobile-menu"
             >
                 {isOpen ? <CloseIcon /> : <MenuIcon />}
             </button>
 
             <div
+                id="mobile-menu"
                 className={`absolute right-4 top-[90px] z-40 w-48 rounded-base border-2 border-border bg-bg text-text transition-all duration-300 ease-in-out dark:border-main dark:bg-darkBg dark:text-main ${
                     isOpen ? 'opacity-100 visible' : 'opacity-0 invisible'
                 }`}


### PR DESCRIPTION
💡 **What:** Added keyboard ('Escape') and mouse (click outside) listeners to close the custom dropdown menu in the `MobileNav` component. Linked the toggle button to the menu content using `aria-controls`.
🎯 **Why:** Custom dropdowns often trap keyboard and screen reader users if standard navigation interactions aren't manually implemented. Clicking outside to close is standard expected behavior for pointer users.
♿ **Accessibility:** Added Escape key support and `aria-controls`/`id` mapping between the toggle button and the expanded menu container.

---
*PR created automatically by Jules for task [1711344108824000755](https://jules.google.com/task/1711344108824000755) started by @indra87g*