### PR TITLE
⚡ Bolt: Optimize LCP by eager loading above-the-fold profile image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,12 +40,15 @@ const projects = projectEntries
 
     <div class="flex flex-col items-center text-center">
       <div class="group relative h-[200px] w-[200px] md:h-[250px] md:w-[250px]">
+        <!-- ⚡ Bolt: Optimize LCP by eager loading above-the-fold profile image -->
         <Image
           height={250}
           width={250}
           src="/profile.jpg"
           alt="indra87g Avatar"
           class="relative z-10 rounded-full border-[6px] border-main bg-main"
+          loading="eager"
+          fetchpriority="high"
         />
         <div
           class="absolute left-0 top-0 -z-10 h-full w-full rounded-full bg-gradient-to-br from-pink-400 to-purple-600 transition-transform group-hover:scale-110"


### PR DESCRIPTION
💡 What: Added `loading="eager"` and `fetchpriority="high"` to the profile `<Image>` component in `src/pages/index.astro`.
🎯 Why: Astro's `<Image>` component defaults to `loading="lazy"`. Since the profile image is located at the top of the homepage (above the fold), lazy loading delays its request, causing an unnecessary delay in Largest Contentful Paint (LCP). Eager loading and prioritizing the fetch resolves this.
📊 Impact: Faster rendering of the main visual element on the homepage, resulting in an improved LCP score.
🔬 Measurement: Verify by checking the network tab or Lighthouse to see that the image request is prioritized and no longer delayed by lazy loading heuristics.

---
*PR created automatically by Jules for task [11299539747089049699](https://jules.google.com/task/11299539747089049699) started by @indra87g*

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b17a028e-ccb5-4efa-beb8-41a2bab1eec0/pull/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->