### PR TITLE
⚡ Bolt: defer hydration of React components in Nav

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2023-10-27 - [Parallelize Multiple Astro Content Collection Fetches]
 **Learning:** Sequential `getCollection` calls in Astro pages (e.g., `const blogs = await getCollection('blog'); const projects = await getCollection('project');`) cause unnecessary I/O and parsing bottlenecks during the build process or SSR, as each collection fetch blocks the next.
 **Action:** Always use `Promise.all` when a page requires fetching multiple distinct collections simultaneously (e.g., `const [blogs, projects] = await Promise.all([getCollection('blog'), getCollection('project')]);`) to optimize data fetching performance.
+## 2024-05-30 - Client Directives in Astro Above-the-fold
+**Learning:** `client:visible` for components that are always visible initially (like headers) adds unnecessary `IntersectionObserver` overhead without deferring work.
+**Action:** Use `client:idle` to actually defer hydration for non-critical interactive components that are immediately visible, freeing up the main thread during initial page load.

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -18,13 +18,13 @@ const pathname = Astro.url.pathname
       <a class={`mr-10 hover:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${pathname.startsWith('/blog') ? 'text-main font-bold' : ''}`} href="/blog" aria-current={pathname.startsWith('/blog') ? 'page' : undefined}>Blog</a>
       <a class={`mr-10 hover:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${pathname.startsWith('/project') ? 'text-main font-bold' : ''}`} href="/project" aria-current={pathname.startsWith('/project') ? 'page' : undefined}>Project</a>
       <a class={`mr-10 hover:text-main rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main ${pathname.startsWith('/cv') ? 'text-main font-bold' : ''}`} href="/cv" aria-current={pathname.startsWith('/cv') ? 'page' : undefined}>CV</a>
-      <ThemeSwitcher client:load />
+      <ThemeSwitcher client:idle />
     </div>
 
     <!-- Mobile Menu -->
     <div class="flex items-center gap-4 md:hidden">
-      <ThemeSwitcher client:load />
-      <MobileNav currentPath={pathname} client:load />
+      <ThemeSwitcher client:idle />
+      <MobileNav currentPath={pathname} client:idle />
     </div>
   </div>
 </nav>

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -27,7 +27,9 @@ test('homepage exposes the skip-to-content a11y link', async ({ page }) => {
 test('cv page is reachable', async ({ page }) => {
     await page.goto('/cv')
     await expect(page).toHaveTitle(/cv/i)
-    await expect(page.getByText('Profil')).toBeVisible()
+    await expect(
+        page.getByText('Profil', { exact: true }).first(),
+    ).toBeVisible()
 })
 
 test('blog listing renders', async ({ page }) => {
@@ -38,5 +40,7 @@ test('blog listing renders', async ({ page }) => {
 test('unknown route serves the custom 404 page', async ({ page }) => {
     await page.goto('/this-route-definitely-does-not-exist')
     await expect(page.getByRole('heading', { name: '404' })).toBeVisible()
-    await expect(page.getByRole('link', { name: /go back home/i })).toBeVisible()
+    await expect(
+        page.getByRole('link', { name: /go back home/i }),
+    ).toBeVisible()
 })


### PR DESCRIPTION
💡 What: The optimization implemented
Changed the hydration directive for `ThemeSwitcher` and `MobileNav` in `src/components/Nav.astro` from `client:load` to `client:idle`.

🎯 Why: The performance problem it solves
`client:load` evaluates and hydrates React components eagerly as soon as the page loads, which blocks the main thread and negatively impacts the Time to Interactive (TTI). Since the `ThemeSwitcher` and `MobileNav` are not critical for initial content rendering and immediate interaction in the first few milliseconds, their hydration can be deferred. We use `client:idle` instead of `client:visible` because these components are placed in the top navigation bar, meaning they are always above the fold. Using `client:visible` on above-the-fold components simply adds `IntersectionObserver` overhead without deferring any work.

📊 Impact: Expected performance improvement
Reduces Total Blocking Time (TBT) and improves Time to Interactive (TTI) by deferring parsing and execution of the React bundle for the navigation components until the browser is idle.

🔬 Measurement: How to verify the improvement
Run performance profiling (like Lighthouse or Chrome DevTools Performance tab) and compare the initial JavaScript execution time and TTI before and after the change.

Also included a small test fix: Fixed a strict mode violation in `tests/smoke.spec.ts` for the CV page test by making the 'Profil' locator exact and selecting the first match.

---
*PR created automatically by Jules for task [5449128444330249970](https://jules.google.com/task/5449128444330249970) started by @indra87g*