### PR TITLE
Add Verdance theme based on Digital Verdance design system

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -53,11 +53,16 @@ const siteDescription = description ?? config.description
     return 'light'
   })()
 
+  document.documentElement.classList.remove('dark')
+  document.documentElement.removeAttribute('data-theme')
+
   if (theme === 'light') {
-    document.documentElement.classList.remove('dark')
     document.documentElement.setAttribute('data-theme', 'github-light')
-  } else {
+  } else if (theme === 'dark') {
     document.documentElement.classList.add('dark')
     document.documentElement.setAttribute('data-theme', 'github-dark')
+  } else if (theme === 'verdance') {
+    document.documentElement.classList.add('dark')
+    document.documentElement.setAttribute('data-theme', 'verdance')
   }
 </script>

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -4,6 +4,21 @@ import config from '@/config'
 export default function ThemeSwitcher() {
     const [theme, setTheme] = useState('light')
 
+    const applyTheme = (newTheme: string) => {
+        document.documentElement.classList.remove('dark')
+        document.documentElement.removeAttribute('data-theme')
+
+        if (newTheme === 'dark') {
+            document.documentElement.classList.add('dark')
+            document.documentElement.setAttribute('data-theme', config.themes.dark)
+        } else if (newTheme === 'light') {
+            document.documentElement.setAttribute('data-theme', config.themes.light)
+        } else if (newTheme === 'verdance') {
+            document.documentElement.classList.add('dark')
+            document.documentElement.setAttribute('data-theme', 'verdance')
+        }
+    }
+
     useEffect(() => {
         const savedTheme = localStorage.getItem('theme')
         const prefersDark = window.matchMedia(
@@ -12,34 +27,26 @@ export default function ThemeSwitcher() {
         const initialTheme = savedTheme ?? (prefersDark ? 'dark' : 'light')
 
         setTheme(initialTheme)
-
-        if (initialTheme === 'dark') {
-            document.documentElement.classList.add('dark')
-        } else {
-            document.documentElement.classList.remove('dark')
-        }
-
-        document.documentElement.setAttribute(
-            'data-theme',
-            config.themes[initialTheme],
-        )
+        applyTheme(initialTheme)
     }, [])
 
-    const handleToggleClick = () => {
-        const newTheme = theme === 'light' ? 'dark' : 'light'
+    const handleToggleClick = (e: React.MouseEvent) => {
+        e.preventDefault();
+        const themes = ['light', 'dark', 'verdance']
+        const currentIndex = themes.indexOf(theme)
+        const nextIndex = (currentIndex + 1) % themes.length
+        const newTheme = themes[nextIndex]
+
         setTheme(newTheme)
         localStorage.setItem('theme', newTheme)
+        applyTheme(newTheme)
+    }
 
-        if (newTheme === 'dark') {
-            document.documentElement.classList.add('dark')
-        } else {
-            document.documentElement.classList.remove('dark')
-        }
-
-        document.documentElement.setAttribute(
-            'data-theme',
-            config.themes[newTheme],
-        )
+    const getNextThemeName = () => {
+        const themes = ['light', 'dark', 'verdance']
+        const currentIndex = themes.indexOf(theme)
+        const nextIndex = (currentIndex + 1) % themes.length
+        return themes[nextIndex]
     }
 
     return (
@@ -47,52 +54,112 @@ export default function ThemeSwitcher() {
             <button
                 type="button"
                 onClick={handleToggleClick}
-                aria-label={
-                    theme === 'dark'
-                        ? 'Switch to light mode'
-                        : 'Switch to dark mode'
-                }
+                aria-label={`Switch to ${getNextThemeName()} mode`}
                 aria-describedby="theme-switcher-tooltip"
                 className="flex items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-main"
             >
-                <svg
-                    className="hidden dark:block"
-                    width="16"
-                    height="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden="true"
-                >
-                    <path
-                        className="fill-darkText"
-                        d="M7 0h2v2H7zM12.88 1.637l1.414 1.415-1.415 1.413-1.413-1.414zM14 7h2v2h-2zM12.95 14.433l-1.414-1.413 1.413-1.415 1.415 1.414zM7 14h2v2H7zM2.98 14.364l-1.413-1.415 1.414-1.414 1.414 1.415zM0 7h2v2H0zM3.05 1.706 4.463 3.12 3.05 4.535 1.636 3.12z"
-                    />
-                    <path
-                        className="fill-darkText"
-                        d="M8 4C5.8 4 4 5.8 4 8s1.8 4 4 4 4-1.8 4-4-1.8-4-4-4Z"
-                    />
-                </svg>
-                <svg
-                    className="dark:hidden"
-                    width="16"
-                    height="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden="true"
-                >
-                    <path
-                        className="fill-text"
-                        d="M6.2 1C3.2 1.8 1 4.6 1 7.9 1 11.8 4.2 15 8.1 15c3.3 0 6-2.2 6.9-5.2C9.7 11.2 4.8 6.3 6.2 1Z"
-                    />
-                    <path
-                        className="fill-text"
-                        d="M12.5 5a.625.625 0 0 1-.625-.625 1.252 1.252 0 0 0-1.25-1.25.625.625 0 1 1 0-1.25 1.252 1.252 0 0 0 1.25-1.25.625.625 0 1 1 1.25 0c.001.69.56 1.249 1.25 1.25a.625.625 0 1 1 0 1.25c-.69.001-1.249.56-1.25 1.25A.625.625 0 0 1 12.5 5Z"
-                    />
-                </svg>
+                {/* Light Icon (Moon-like icon from original) */}
+                {theme === 'light' && (
+                    <svg
+                        width="16"
+                        height="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true"
+                    >
+                        <path
+                            className="fill-text"
+                            d="M6.2 1C3.2 1.8 1 4.6 1 7.9 1 11.8 4.2 15 8.1 15c3.3 0 6-2.2 6.9-5.2C9.7 11.2 4.8 6.3 6.2 1Z"
+                        />
+                        <path
+                            className="fill-text"
+                            d="M12.5 5a.625.625 0 0 1-.625-.625 1.252 1.252 0 0 0-1.25-1.25.625.625 0 1 1 0-1.25 1.252 1.252 0 0 0 1.25-1.25.625.625 0 1 1 1.25 0c.001.69.56 1.249 1.25 1.25a.625.625 0 1 1 0 1.25c-.69.001-1.249.56-1.25 1.25A.625.625 0 0 1 12.5 5Z"
+                        />
+                    </svg>
+                )}
+                {/* Dark Icon (Sun-like icon from original) */}
+                {theme === 'dark' && (
+                    <svg
+                        width="16"
+                        height="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true"
+                    >
+                        <path
+                            className="fill-text"
+                            d="M7 0h2v2H7zM12.88 1.637l1.414 1.415-1.415 1.413-1.413-1.414zM14 7h2v2h-2zM12.95 14.433l-1.414-1.413 1.413-1.415 1.415 1.414zM7 14h2v2H7zM2.98 14.364l-1.413-1.415 1.414-1.414 1.414 1.415zM0 7h2v2H0zM3.05 1.706 4.463 3.12 3.05 4.535 1.636 3.12z"
+                        />
+                        <path
+                            className="fill-text"
+                            d="M8 4C5.8 4 4 5.8 4 8s1.8 4 4 4 4-1.8 4-4-1.8-4-4-4Z"
+                        />
+                    </svg>
+                )}
+                {/* Verdance Icon (Plant/Leaf inspired) */}
+                {theme === 'verdance' && (
+                    <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true"
+                    >
+                        <path
+                            d="M12 22C12 22 20 18 20 12C20 6 12 2 12 2C12 2 4 6 4 12C4 18 12 22 12 22Z"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="stroke-text"
+                        />
+                        <path
+                            d="M12 2V22"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="stroke-text"
+                        />
+                        <path
+                            d="M12 12C12 12 15 9 18 9"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="stroke-text"
+                        />
+                        <path
+                            d="M12 17C12 17 15 14 18 14"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="stroke-text"
+                        />
+                        <path
+                            d="M12 12C12 12 9 9 6 9"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="stroke-text"
+                        />
+                        <path
+                            d="M12 17C12 17 9 14 6 14"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="stroke-text"
+                        />
+                    </svg>
+                )}
             </button>
             <span
                 id="theme-switcher-tooltip"
                 className="absolute top-8 left-1/2 -translate-x-1/2 scale-0 transition-all rounded bg-gray-800 p-2 text-xs text-white group-hover:scale-100 group-focus-within:scale-100"
             >
-                Switch to {theme === 'dark' ? 'light' : 'dark'} mode
+                Switch to {getNextThemeName()} mode
             </span>
         </div>
     )

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ type Config = {
     themes: {
         dark: ThemeObjectOrShikiThemeName
         light: ThemeObjectOrShikiThemeName
+        verdance: ThemeObjectOrShikiThemeName
     }
     // Personal profile (homepage, etc.)
     profile: {
@@ -42,6 +43,7 @@ export default {
     themes: {
         dark: 'github-dark',
         light: 'github-light',
+        verdance: 'github-dark',
     },
     profile: {
         username: 'indra87g',

--- a/src/global.css
+++ b/src/global.css
@@ -1,5 +1,50 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
+    --bg: #FEF2E8;
+    --text: #000000;
+    --border: #000000;
+    --main: #FFDC58;
+    --main-accent: #ffc800;
+    --secondary-black: #212121;
+    --radius: 10px;
+    --shadow: 0px 4px 0px 0px #000;
+}
+
+.dark {
+    --bg: #374151;
+    --text: #eeefe9;
+    --border: #000000;
+    --main: #FFDC58;
+    --main-accent: #ffc800;
+    --secondary-black: #212121;
+    --radius: 10px;
+    --shadow: 0px 4px 0px 0px #000;
+}
+
+[data-theme="verdance"] {
+    --bg: #0e150f;
+    --text: #dde5da;
+    --border: #414941;
+    --main: #6bfb9a;
+    --main-accent: #00522c;
+    --secondary-black: #1a211a;
+    --radius: 0px;
+    --shadow: 0px 0px 0px 0px transparent;
+}
+
+@layer base {
+  html {
     transition: color 200ms ease-in-out, background-color 200ms ease-in-out;
+    background-color: var(--bg);
+    color: var(--text);
+  }
+  body {
+    background-color: transparent;
+    color: inherit;
+  }
 }
 
 mark {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -19,7 +19,7 @@ const {
     <script defer src="https://cloud.umami.is/script.js" data-website-id="cfdc498a-5723-48b5-874b-a126717a68bb" is:inline></script>
   </head>
   <body
-    class="min-h-screen bg-bg px-5 font-base text-text scrollbar scrollbar-thumb-black dark:bg-darkBg dark:text-darkText dark:scrollbar-thumb-white flex flex-col"
+    class="min-h-screen bg-bg px-5 font-base text-text scrollbar scrollbar-thumb-black dark:scrollbar-thumb-white flex flex-col"
   >
     <a
       href="#main-content"
@@ -35,7 +35,7 @@ const {
     >
       <div class="flex justify-center">
         <div
-          class="w-full rounded-base border-2 border-border p-6 pt-10 shadow-light dark:border-darkBorder dark:shadow-dark transition-colors duration-300"
+          class="w-full rounded-base border-2 border-border p-6 pt-10 shadow-light transition-colors duration-300"
         >
           <slot />
         </div>
@@ -47,22 +47,27 @@ const {
       import config from '@/config'
 
       function colorMode() {
-        if (
-          localStorage.theme === 'dark' ||
-          (!('theme' in localStorage) &&
-            window.matchMedia('(prefers-color-scheme: dark)').matches)
-        ) {
-          document.documentElement.classList.add('dark')
-          document.documentElement.setAttribute(
-            'data-theme',
-            config.themes.dark as string,
-          )
-        } else {
-          document.documentElement.classList.remove('dark')
-          document.documentElement.setAttribute(
-            'data-theme',
-            config.themes.light as string,
-          )
+        const theme = (() => {
+            if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+                return localStorage.getItem('theme')
+            }
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                return 'dark'
+            }
+            return 'light'
+        })()
+
+        document.documentElement.classList.remove('dark')
+        document.documentElement.removeAttribute('data-theme')
+
+        if (theme === 'light') {
+            document.documentElement.setAttribute('data-theme', config.themes.light as string)
+        } else if (theme === 'dark') {
+            document.documentElement.classList.add('dark')
+            document.documentElement.setAttribute('data-theme', config.themes.dark as string)
+        } else if (theme === 'verdance') {
+            document.documentElement.classList.add('dark')
+            document.documentElement.setAttribute('data-theme', 'verdance')
         }
       }
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -11,27 +11,25 @@ export default {
                 sans: ['Inter', ...defaultTheme.fontFamily.sans],
             },
             colors: {
-                main: '#FFDC58',
-                mainAccent: '#ffc800', // not needed for shadcn components
+                main: 'var(--main)',
+                mainAccent: 'var(--main-accent)', // not needed for shadcn components
                 overlay: 'rgba(0,0,0,0.8)', // background color overlay for alert dialogs, modals, etc.
 
-                // light mode
-                bg: '#FEF2E8',
-                text: '#000',
-                border: '#000',
+                bg: 'var(--bg)',
+                text: 'var(--text)',
+                border: 'var(--border)',
 
-                // dark mode
-                darkBg: '#374151',
-                darkText: '#eeefe9',
-                darkBorder: '#000',
-                secondaryBlack: '#212121', // opposite of plain white, not used pitch black because borders and box-shadows are that color
+                darkBg: 'var(--bg)',
+                darkText: 'var(--text)',
+                darkBorder: 'var(--border)',
+                secondaryBlack: 'var(--secondary-black)', // opposite of plain white, not used pitch black because borders and box-shadows are that color
             },
             borderRadius: {
-                base: '10px',
+                base: 'var(--radius)',
             },
             boxShadow: {
-                light: '0px 4px 0px 0px #000',
-                dark: '0px 4px 0px 0px #000',
+                light: 'var(--shadow)',
+                dark: 'var(--shadow)',
             },
             translate: {
                 boxShadowX: '0px',
@@ -51,18 +49,18 @@ export default {
             typography: (theme) => ({
                 lightMode: {
                     css: {
-                        '--tw-prose-kbd': theme('colors.text'),
-                        '--tw-prose-quote-borders': theme('colors.text'),
-                        '--tw-prose-bullets': theme('colors.text'),
-                        '--tw-prose-code': theme('colors.text'),
+                        '--tw-prose-kbd': 'var(--text)',
+                        '--tw-prose-quote-borders': 'var(--text)',
+                        '--tw-prose-bullets': 'var(--text)',
+                        '--tw-prose-code': 'var(--text)',
                     },
                 },
                 darkMode: {
                     css: {
-                        '--tw-prose-kbd': theme('colors.darkText'),
-                        '--tw-prose-quote-borders': theme('colors.darkText'),
-                        '--tw-prose-bullets': theme('colors.darkText'),
-                        '--tw-prose-code': theme('colors.darkText'),
+                        '--tw-prose-kbd': 'var(--text)',
+                        '--tw-prose-quote-borders': 'var(--text)',
+                        '--tw-prose-bullets': 'var(--text)',
+                        '--tw-prose-code': 'var(--text)',
                     },
                 },
             }),


### PR DESCRIPTION
This PR adds a new theme named 'verdance' which follows the Digital Verdance design system. It refactors the existing styling to use CSS variables, allowing for easy theme switching between light, dark, and verdance. The theme switcher has been updated to cycle through all three themes. Visual verification has been performed.

---
*PR created automatically by Jules for task [3150234637242040016](https://jules.google.com/task/3150234637242040016) started by @indra87g*