### PR TITLE
⚡ Bolt: Cache git commit info to optimize Astro build times

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 ## 2026-06-20 - [Replace Unthrottled Resize Listeners with MatchMedia]
 **Learning:** Using `window.addEventListener('resize', ...)` to track breakpoints in React components (like responsive nav menus) is a performance anti-pattern. It fires hundreds of times during a resize operation, causing synchronous evaluations of `window.innerWidth` on the main thread, which can lead to UI jank and layout thrashing.
 **Action:** When tracking CSS breakpoints in JS/React, always use `window.matchMedia('(min-width: ...px)').addEventListener('change', ...)`. This native API is vastly more efficient as it fires exactly once when the specific breakpoint is crossed, completely eliminating the continuous overhead of the resize event.
+
+## 2026-06-28 - [Cache Expensive Sync Operations During Astro Build]
+**Learning:** In Astro static site generation, synchronous operations like `execSync` placed in layout or frequently used component scripts (like `Footer.astro`) execute individually for *every* page generated. This sequentially blocks the main thread, causing severe build slowdowns as the site grows.
+**Action:** Always cache the results of expensive, invariant synchronous operations (like fetching git commit info) in the module scope or using `globalThis` so they execute only once per build process, significantly improving `pnpm build` times.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,18 +3,26 @@ import { execSync } from 'node:child_process'
 import { Icon } from 'astro-icon/components'
 
 const today = new Date()
-let commitMessage = 'No commit info'
-let commitSha = 'unknown'
 
-try {
-    commitMessage = execSync(
-        'git log -1 --pretty=%B --invert-grep --grep="^Apply patch"',
-    )
-        .toString()
-        .trim()
-    commitSha = execSync('git rev-parse --short HEAD').toString().trim()
-} catch (e) {
-    console.error('Error getting git info:', e)
+// ⚡ Bolt: Cache git commit info in globalThis to prevent redundant synchronous `execSync`
+// execution for every single page rendered during the build process, reducing build time.
+let commitMessage = globalThis.__BOLT_GIT_COMMIT_MSG || 'No commit info'
+let commitSha = globalThis.__BOLT_GIT_COMMIT_SHA || 'unknown'
+
+if (!globalThis.__BOLT_GIT_COMMIT_MSG) {
+    try {
+        commitMessage = execSync(
+            'git log -1 --pretty=%B --invert-grep --grep="^Apply patch"',
+        )
+            .toString()
+            .trim()
+        commitSha = execSync('git rev-parse --short HEAD').toString().trim()
+
+        globalThis.__BOLT_GIT_COMMIT_MSG = commitMessage
+        globalThis.__BOLT_GIT_COMMIT_SHA = commitSha
+    } catch (e) {
+        console.error('Error getting git info:', e)
+    }
 }
 ---
 


### PR DESCRIPTION
During the static generation phase (`pnpm build`), Astro evaluates the component script block for each page it generates. The `Footer.astro` component was running two synchronous `execSync` shell commands (`git log` and `git rev-parse`) to display the latest commit.

Because this footer is included in the base layout, `execSync` was being evaluated sequentially for every single page rendered, needlessly blocking the main thread during the build process and slowing down generation times as the site grew.

This optimization memoizes the `execSync` output using `globalThis` to store the result. Since the git commit info remains constant across pages during a single build process, the shell commands now only execute once per build.

### 💡 What
Cached the result of synchronous git commands in `Footer.astro` using `globalThis.__BOLT_GIT_COMMIT_MSG` and `globalThis.__BOLT_GIT_COMMIT_SHA`.

### 🎯 Why
To prevent redundant child process executions on the main thread for every single page generated during Astro's static site generation.

### 📊 Impact
Build time for the static generation phase is measurably faster by avoiding dozens of redundant `execSync` blockages.

### 🔬 Measurement
Run `pnpm build` and observe that static routes are generated faster. Test passed correctly.

---
*PR created automatically by Jules for task [11586631052128942092](https://jules.google.com/task/11586631052128942092) started by @indra87g*