### PR TITLE
⚡ Bolt: Enable Astro Prefetching and ClientRouter for instant navigations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2026-06-28 - [Cache Expensive Sync Operations During Astro Build]
 **Learning:** In Astro static site generation, synchronous operations like `execSync` placed in layout or frequently used component scripts (like `Footer.astro`) execute individually for *every* page generated. This sequentially blocks the main thread, causing severe build slowdowns as the site grows.
 **Action:** Always cache the results of expensive, invariant synchronous operations (like fetching git commit info) in the module scope or using `globalThis` so they execute only once per build process, significantly improving `pnpm build` times.
+
+## 2023-10-27 - [Enable Astro Prefetching and ClientRouter]
+**Learning:** Out-of-the-box Astro performs full page reloads on navigation. For content-heavy sites (like blogs or portfolios), this creates unnecessary latency and screen flashes.
+**Action:** Always enable `prefetch` in `astro.config.ts` (e.g., `prefetch: { prefetchAll: true, defaultStrategy: 'hover' }`) to fetch resources before the user clicks, and include `<ClientRouter />` (from `astro:transitions`) in the `<head>` to enable SPA-like in-place DOM updates for near-instant navigations.

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -35,4 +35,8 @@ export default defineConfig({
 
     site: 'https://indra87g.is-a.dev/',
     output: 'static',
+    prefetch: {
+        prefetchAll: true,
+        defaultStrategy: 'hover',
+    },
 })

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,4 +1,6 @@
 ---
+import { ClientRouter } from 'astro:transitions'
+
 import config from '@/config'
 
 interface Props {
@@ -41,6 +43,8 @@ const siteDescription = description ?? config.description
   <meta property="twitter:url" content={Astro.url} />
   <meta property="twitter:title" content={siteTitle} />
   <meta property="twitter:description" content={siteDescription} />
+
+  <ClientRouter />
 
 <script is:inline>
   const theme = (() => {


### PR DESCRIPTION
⚡ Bolt: Enable Astro Prefetching and ClientRouter for instant navigations

💡 What:
- Added `prefetch: { prefetchAll: true, defaultStrategy: 'hover' }` to `astro.config.ts`.
- Added `<ClientRouter />` (from `astro:transitions`) to the `<head>` in `src/components/BaseHead.astro`.

🎯 Why:
Out-of-the-box Astro performs full page reloads on navigation, which can create unnecessary latency and screen flashes. Enabling prefetching downloads HTML in the background when the user hovers over links, and ClientRouter updates the DOM in-place without a full reload, creating a seamless SPA-like navigation experience.

📊 Impact:
Near-instant perceived navigation speed between site pages, eliminating full-page load times and flashes of unstyled content.

🔬 Measurement:
Hover over links and observe network requests prefetching the pages. Click links and observe that the page updates instantly without a browser reload.

---
*PR created automatically by Jules for task [13774339020338763101](https://jules.google.com/task/13774339020338763101) started by @indra87g*