### PR TITLE
⚡ Bolt: defer MobileNav hydration to mobile viewports

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 ## 2024-05-30 - [Eliminate Redundant React Islands & Inline Theme Scripts]
 **Learning:** Rendering multiple instances of the same React component (like `ThemeSwitcher` for desktop and mobile) inside Astro islands (`client:idle`) forces the client to download, parse, and hydrate multiple identical component states, duplicating DOM nodes and event listeners unnecessarily. Furthermore, calling theme initialization functions (like `colorMode()`) immediately after an identical inline `<script>` already blocked parsing in `<head>` causes redundant and expensive layout thrashing.
 **Action:** Structure layouts to share a single React interactive component instance when possible, using CSS breakpoints (`hidden md:flex`) to display it contextually. Also, audit theme toggle scripts to ensure initial application logic only executes once per page load to prevent FOUC without duplicate execution overhead.
+
+## 2024-05-30 - [Defer Hydration of Hidden Mobile Components]
+**Learning:** Using `client:idle` for conditionally hidden components (like a mobile nav menu with `md:hidden`) causes desktop clients to needlessly download and hydrate JavaScript that they will never use, wasting bandwidth and CPU cycles.
+**Action:** When a component is only visible on certain viewports via CSS breakpoints, use the corresponding Astro `client:media` directive (e.g., `client:media="(max-width: 767px)"`) to guarantee the JS is only loaded and executed when the component can actually be interacted with.

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -25,7 +25,7 @@ const pathname = Astro.url.pathname
     <div class="flex items-center gap-4 md:gap-0">
       <ThemeSwitcher client:idle />
       <div class="md:hidden ml-4">
-        <MobileNav currentPath={pathname} client:idle />
+        <MobileNav currentPath={pathname} client:media="(max-width: 767px)" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
💡 **What:** Changed the Astro client directive on the `<MobileNav />` component in `src/components/Nav.astro` from `client:idle` to `client:media="(max-width: 767px)"`.

🎯 **Why:** The mobile navigation menu is visually hidden on desktop viewports via Tailwind's `md:hidden` class. However, by using `client:idle`, Astro was still forcing desktop browsers to download, parse, and hydrate the React component in the background. By using `client:media`, we ensure the component's JavaScript is *only* loaded and executed when the viewport matches the media query (i.e., when the menu is actually capable of being seen and interacted with).

📊 **Impact:** 
- Reduces the amount of JavaScript downloaded by desktop users.
- Eliminates unnecessary React hydration overhead on the main thread for desktop clients.
- Prevents the setup of unused event listeners (click outside, escape key) on desktop.

🔬 **Measurement:** You can verify this improvement by opening the site on a desktop viewport (> 768px), opening DevTools -> Network tab (filtered by JS), and confirming that the React chunk responsible for `MobileNav` is no longer requested. Resizing the window down to a mobile size will trigger the chunk download dynamically.

---
*PR created automatically by Jules for task [7043513811183796345](https://jules.google.com/task/7043513811183796345) started by @indra87g*