### PR TITLE
⚡ Bolt: Eager load above-the-fold card images for faster LCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 ## 2024-05-30 - [Defer Hydration of Hidden Mobile Components]
 **Learning:** Using `client:idle` for conditionally hidden components (like a mobile nav menu with `md:hidden`) causes desktop clients to needlessly download and hydrate JavaScript that they will never use, wasting bandwidth and CPU cycles.
 **Action:** When a component is only visible on certain viewports via CSS breakpoints, use the corresponding Astro `client:media` directive (e.g., `client:media="(max-width: 767px)"`) to guarantee the JS is only loaded and executed when the component can actually be interacted with.
+
+## 2024-05-30 - [Eager Load Dynamic Card Images for LCP]
+**Learning:** While Astro's `<Image />` component defaults to `loading="lazy"` (which is excellent for general performance), applying this blindly to dynamically generated card grids (like recent posts or projects on a homepage or paginated lists) causes significant LCP (Largest Contentful Paint) regressions. The first few cards are often above the fold, and delaying their image load negatively impacts perceived performance.
+**Action:** When mapping over content collections to render card grids, always use the map `index` to selectively apply `loading="eager"` and `fetchpriority="high"` to the first 1-2 items (e.g., `loading={index < 2 ? 'eager' : 'lazy'}`). Ensure the underlying Card components are updated to accept and pass through these attributes.

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,7 +1,16 @@
 ---
 import { Image } from 'astro:assets'
-const { url, heroImage, heroAlt, title, description, draft, publishDate } =
-    Astro.props
+const {
+    url,
+    heroImage,
+    heroAlt,
+    title,
+    description,
+    draft,
+    publishDate,
+    loading = 'lazy',
+    fetchpriority = 'auto',
+} = Astro.props
 ---
 
 <a
@@ -14,6 +23,8 @@ const { url, heroImage, heroAlt, title, description, draft, publishDate } =
     src={heroImage}
     alt={heroAlt}
     class="hover:transform-perspective mb-2 rounded-t-2xl transition-transform duration-300"
+    loading={loading}
+    fetchpriority={fetchpriority}
   />
   <h2 class="text-xl font-heading w500:text-lg">
     {title}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,7 +1,16 @@
 ---
 import { Image } from 'astro:assets'
-const { url, heroImage, heroAlt, title, description, draft, publishDate } =
-    Astro.props
+const {
+    url,
+    heroImage,
+    heroAlt,
+    title,
+    description,
+    draft,
+    publishDate,
+    loading = 'lazy',
+    fetchpriority = 'auto',
+} = Astro.props
 ---
 
 <a
@@ -14,6 +23,8 @@ const { url, heroImage, heroAlt, title, description, draft, publishDate } =
     src={heroImage}
     alt={heroAlt}
     class="hover:transform-perspective mb-2 rounded-t-2xl transition-transform duration-300"
+    loading={loading}
+    fetchpriority={fetchpriority}
   />
   <h2 class="text-xl font-heading w500:text-lg">
     {title}

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -28,7 +28,7 @@ const { page } = Astro.props
 <Base meta={{ title: `${config.title} - Blog` }}>
   <div class="grid grid-cols-2 gap-5 w700:grid-cols-1">
     {
-      page.data.map((post) => (
+      page.data.map((post, index) => (
         <Card
           url={post.slug}
           heroImage={post.data.heroImage}
@@ -37,6 +37,8 @@ const { page } = Astro.props
           title={post.data.title}
           description={post.data.description}
           publishDate={formatDate(post.data.publishDate)}
+          loading={index < 2 ? 'eager' : 'lazy'}
+          fetchpriority={index < 2 ? 'high' : 'auto'}
         />
       ))
     }

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -35,7 +35,7 @@ const { posts } = Astro.props
   </h2>
   <div class="grid grid-cols-2 gap-5 w700:grid-cols-1">
     {
-      posts.map((post) => (
+      posts.map((post, index) => (
         <Card
           url={`/${post.slug}`}
           heroImage={post.data.heroImage}
@@ -43,6 +43,8 @@ const { posts } = Astro.props
           title={post.data.title}
           description={post.data.description}
           publishDate={formatDate(post.data.publishDate)}
+          loading={index < 2 ? 'eager' : 'lazy'}
+          fetchpriority={index < 2 ? 'high' : 'auto'}
         />
       ))
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -71,7 +71,7 @@ const projects = projectEntries
     <h2 class="text-3xl font-bold text-center">Recent Posts</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-8">
       {
-        posts.map((post) => (
+        posts.map((post, index) => (
           <PostCard
             url={`/blog/${post.slug}`}
             title={post.data.title}
@@ -79,6 +79,8 @@ const projects = projectEntries
             publishDate={post.data.publishDate.toISOString().slice(0, 10)}
             heroImage={post.data.heroImage}
             heroAlt={post.data.heroAlt}
+            loading={index < 2 ? 'eager' : 'lazy'}
+            fetchpriority={index < 2 ? 'high' : 'auto'}
           />
         ))
       }
@@ -89,7 +91,7 @@ const projects = projectEntries
     <h2 class="text-3xl font-bold text-center">Recent Projects</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-8">
       {
-        projects.map((project) => (
+        projects.map((project, index) => (
           <ProjectCard
             url={`/project/${project.slug}`}
             title={project.data.title}
@@ -97,6 +99,8 @@ const projects = projectEntries
             publishDate={project.data.publishDate.toISOString().slice(0, 10)}
             heroImage={project.data.heroImage}
             heroAlt={project.data.heroAlt}
+            loading={index < 2 ? 'eager' : 'lazy'}
+            fetchpriority={index < 2 ? 'high' : 'auto'}
           />
         ))
       }

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -28,7 +28,7 @@ const { page } = Astro.props
 <Base meta={{ title: `${config.title} - Project` }}>
   <div class="grid grid-cols-2 gap-5 w700:grid-cols-1">
     {
-      page.data.map((project) => (
+      page.data.map((project, index) => (
         <Card
           url={project.slug}
           heroImage={project.data.heroImage}
@@ -37,6 +37,8 @@ const { page } = Astro.props
           title={project.data.title}
           description={project.data.description}
           publishDate={formatDate(project.data.publishDate)}
+          loading={index < 2 ? 'eager' : 'lazy'}
+          fetchpriority={index < 2 ? 'high' : 'auto'}
         />
       ))
     }

--- a/src/pages/project/tags/[tag].astro
+++ b/src/pages/project/tags/[tag].astro
@@ -35,7 +35,7 @@ const { projects } = Astro.props
   </h2>
   <div class="grid grid-cols-2 gap-5 w700:grid-cols-1">
     {
-      projects.map((project) => (
+      projects.map((project, index) => (
         <Card
           url={`/${project.slug}`}
           heroImage={project.data.heroImage}
@@ -43,6 +43,8 @@ const { projects } = Astro.props
           title={project.data.title}
           description={project.data.description}
           publishbDate={formatDate(project.data.publishDate)}
+          loading={index < 2 ? 'eager' : 'lazy'}
+          fetchpriority={index < 2 ? 'high' : 'auto'}
         />
       ))
     }


### PR DESCRIPTION
💡 What: Modified `PostCard.astro` and `ProjectCard.astro` to accept `loading` and `fetchpriority` properties, passing them to the underlying Astro `<Image />` component. Then updated `src/pages/index.astro`, `src/pages/blog/[...page].astro`, `src/pages/blog/tags/[tag].astro`, `src/pages/project/[...page].astro`, and `src/pages/project/tags/[tag].astro` to selectively pass `loading="eager"` and `fetchpriority="high"` to the first two items in their grids using the `.map()` index.

🎯 Why: Astro's `<Image />` component defaults to `loading="lazy"`. While great for general performance, this creates an LCP regression for dynamically generated card grids where the first few items appear above the fold on initial load. The browser must wait for the DOM to parse and the IntersectionObserver to fire before requesting the critical images.

📊 Impact: Reduces LCP times by explicitly instructing the browser to eagerly load and prioritize the first row of images, preventing them from delaying the initial perceived page load.

🔬 Measurement: Verify by running `pnpm build && pnpm preview` and inspecting the network tab or running Lighthouse. The first two images in the recent posts/projects sections will load immediately without the `loading="lazy"` attribute. Tests verify no visual regressions occur.

---
*PR created automatically by Jules for task [9252593849766144094](https://jules.google.com/task/9252593849766144094) started by @indra87g*